### PR TITLE
Release tag, manage packages and OSM elements, slices management, test plans, dashboard fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ There is also a version of the Portal for using the 5GTANGO Service Development 
 
 <p align="center"><img src="https://github.com/sonata-nfv/tng-portal/blob/master/src/assets/images/5GTANGO.gif" /></p>
 
-## Dependencies
+## Installation
+
+Make sure that you have all the dependencies installed. Then, run the following command to install all the required modules.
+
+```
+npm install
+```
+
+### Dependencies
 
 - Node.js >= v8.9
 
@@ -29,19 +37,9 @@ There is also a version of the Portal for using the 5GTANGO Service Development 
 [sudo] npm install -g @angular/cli
 ```
 
-### Running dependencies
+- Athens VPN credentials: requests made from the Portal in the development mode need the VPN in order to receive a response.
 
-Requests made from the Portal in the development mode need the VPN in order to receive a response.
-
-- Athens VPN credentials
-
-## Installation
-
-Make sure that you have all the dependencies installed. Then, run the following command to install all the required modules.
-
-```
-npm install
-```
+- Make sure you have installed [Docker](https://docs.docker.com/install/) >= 18.06.0-ce if you are going to deploy the Portal like this.
 
 ## Developing
 
@@ -62,15 +60,7 @@ If you want to launch a container locally, place yourself in the Dockerfile fold
 
 The container should be up and running in http://0.0.0.0:80.
 
-#### Exposed port in docker container
-
-The port where the app will run when using the Docker container can be set in `./Dockerfile`. By default, 4200 is set.
-
-#### Docker dependencies
-
-Make sure you have installed Docker >= 18.06.0-ce
-
-- [https://docs.docker.com/install/](https://docs.docker.com/install/)
+*Note: The port where the app will run when using the Docker container can be set in `./Dockerfile`. By default, 4200 is set.*
 
 ## Configuration
 Portal allows two different configurations: the base URL of the deployment and the displayed sections of the menu.

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -720,3 +720,10 @@ ul.unordered-list .mat-input-element:disabled {
 		color: $secondary-font-color;
 	}
 }
+
+//////////////////////////////////////
+// Generic styles
+//////////////////////////////////////
+.opening-item {
+	cursor: pointer;
+}

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -169,8 +169,8 @@
 		<h3 class="title3" i18n="@@testsStatus">Tests status</h3>
 
 		<div class="text-box big">
-			<span class="title" i18n="@@executed">Executed</span>
-			<span class="number">{{ dashboardData['testsExecuted'] }}</span>
+			<span class="title" i18n="@@completed">Completed</span>
+			<span class="number">{{ dashboardData['testsCompleted'] }}</span>
 		</div>
 
 		<div class="text-box big">

--- a/src/app/service-management/ns-instance-detail/ns-instance-detail.component.html
+++ b/src/app/service-management/ns-instance-detail/ns-instance-detail.component.html
@@ -29,8 +29,8 @@
 				<i class="wui wui-copy-alt"></i>
 			</button>
 		</mat-form-field>
-		<mat-form-field *ngIf="detail['serviceVersion']" class="right-column">
-			<input matInput placeholder="Service version" value="{{ detail['serviceVersion'] }}" [disabled]="true"
+		<mat-form-field *ngIf="detail['serviceVersion']" class="right-column" (click)="openService()">
+			<input matInput class="opening-item" placeholder="Service version" value="{{ detail['serviceVersion'] }}" [disabled]="true"
 				i18n-placeholder="@@serviceVersionPlaceholder" />
 		</mat-form-field>
 	</div>

--- a/src/app/service-management/ns-instance-detail/ns-instance-detail.component.ts
+++ b/src/app/service-management/ns-instance-detail/ns-instance-detail.component.ts
@@ -129,6 +129,10 @@ export class NsInstanceDetailComponent implements OnInit {
 		this.utilsService.copyToClipboard(value);
 	}
 
+	openService() {
+		this.router.navigate([ `service-management/network-services/services/${ this.detail[ 'serviceID' ] }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-management/request-detail/request-detail.component.html
+++ b/src/app/service-management/request-detail/request-detail.component.html
@@ -37,8 +37,9 @@
 	</div>
 
 	<div class="same-row">
-		<mat-form-field *ngIf="detail['serviceName']" class="left-column">
-			<input matInput placeholder="Service Name" value="{{ detail['serviceName'] }}" disabled i18n="@@serviceNamePlaceholder" />
+		<mat-form-field *ngIf="detail['serviceName']" class="left-column" (click)="openService()">
+			<input matInput class="opening-item" placeholder="Service Name" value="{{ detail['serviceName'] }}" disabled
+				i18n="@@serviceNamePlaceholder" />
 		</mat-form-field>
 
 		<mat-form-field *ngIf="detail['serviceVersion']" class="right-column">

--- a/src/app/service-management/request-detail/request-detail.component.ts
+++ b/src/app/service-management/request-detail/request-detail.component.ts
@@ -51,6 +51,10 @@ export class RequestDetailComponent implements OnInit {
 		this.utilsService.copyToClipboard(value);
 	}
 
+	openService() {
+		this.router.navigate([ `service-management/network-services/services/${ this.detail[ 'serviceUUID' ] }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-management/slice-instance-detail/slice-instance-detail.component.html
+++ b/src/app/service-management/slice-instance-detail/slice-instance-detail.component.html
@@ -30,8 +30,8 @@
 	</mat-form-field>
 
 	<div class="same-row">
-		<mat-form-field *ngIf="detail['nstName']" class="left-column">
-			<input matInput placeholder="Template name" value="{{ detail['nstName'] }}" disabled
+		<mat-form-field *ngIf="detail['nstName']" class="left-column" (click)="openTemplate()">
+			<input matInput class="opening-item" placeholder="Template name" value="{{ detail['nstName'] }}" disabled
 				i18n-placeholder="@@templateNamePlaceholder" />
 		</mat-form-field>
 		<mat-form-field *ngIf="detail['vendor']">

--- a/src/app/service-management/slice-instance-detail/slice-instance-detail.component.ts
+++ b/src/app/service-management/slice-instance-detail/slice-instance-detail.component.ts
@@ -78,6 +78,10 @@ export class SliceInstanceDetailComponent implements OnInit {
 		return this.detail[ 'uuid' ] && this.detail[ 'status' ].toUpperCase() === 'INSTANTIATED';
 	}
 
+	openTemplate() {
+		this.router.navigate([ `service-management/slices/slice-templates/${ this.detail[ 'nstRef' ] }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-management/sm-network-services/sm-network-services.component.html
+++ b/src/app/service-management/sm-network-services/sm-network-services.component.html
@@ -39,7 +39,7 @@
 	</ng-container>
 
 	<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-	<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openNetworkService(row.serviceId)"></tr>
+	<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openNetworkService(row.uuid)"></tr>
 </table>
 
 <div *ngIf="(!networkServices || !networkServices.length) && !loading" class="no-results-container">

--- a/src/app/service-management/sm-network-services/sm-network-services.component.ts
+++ b/src/app/service-management/sm-network-services/sm-network-services.component.ts
@@ -65,7 +65,7 @@ export class SmNetworkServicesComponent implements OnInit {
 
 	instantiate(row) {
 		this.instantiateDialog.open(NsInstantiateDialogComponent, {
-			data: { serviceUUID: row.serviceId, name: row.name }
+			data: { serviceUUID: row.uuid, name: row.name }
 		});
 	}
 }

--- a/src/app/service-management/sm-slice-template-detail/sm-slice-template-detail.component.html
+++ b/src/app/service-management/sm-slice-template-detail/sm-slice-template-detail.component.html
@@ -102,7 +102,7 @@
 	</ng-container>
 
 	<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-	<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+	<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow(row)"></tr>
 </table>
 
 <div *ngIf="(detail['services'] && !detail['services'].length) && !loading" class="no-results-container">
@@ -113,7 +113,7 @@
 
 <h2 *ngIf="detail['sliceVirtualLinks']" class="title2" i18n="@@sliceVirtualLinks">Slice virtual links</h2>
 
-<table *ngIf="detail['sliceVirtualLinks']" mat-table [dataSource]="detail['sliceVirtualLinks']">
+<table *ngIf="detail['sliceVirtualLinks']" class="no-opening-table" mat-table [dataSource]="detail['sliceVirtualLinks']">
 	<ng-container matColumnDef="networkName">
 		<th mat-header-cell *matHeaderCellDef i18n="@@networkName">Network Name</th>
 		<td mat-cell *matCellDef="let element">{{ element.networkName }}</td>

--- a/src/app/service-management/sm-slice-template-detail/sm-slice-template-detail.component.scss
+++ b/src/app/service-management/sm-slice-template-detail/sm-slice-template-detail.component.scss
@@ -35,29 +35,29 @@ app-sm-slice-template-detail {
 	table {
 		width: 55vw;
 		margin-bottom: 50px;
+	
+		tr.mat-row {
+			background-image: linear-gradient(
+				to right,
+				$basic-background-color 0%,
+				$table-underline-color 0%,
+				$table-underline-color 99%,
+				$basic-background-color 99%,
+				$basic-background-color 100%
+				);
+		}
+			
+		&.no-opening-table td.mat-cell {
+			cursor: auto;
+		}
+
+		.mat-cell:nth-child(6),
+		.mat-header-cell:nth-child(6) {
+			width: 16%;
+			padding-right: 0;
+		}
 	}
 	
-	tr.mat-row {
-		background-image: linear-gradient(
-			to right,
-			$basic-background-color 0%,
-			$table-underline-color 0%,
-			$table-underline-color 99%,
-			$basic-background-color 99%,
-			$basic-background-color 100%
-			);
-	}
-		
-	td.mat-cell {
-		cursor: auto;
-	}
-
-	.mat-cell:nth-child(6),
-	.mat-header-cell:nth-child(6) {
-		width: 16%;
-		padding-right: 0;
-	}
-
 	// Styles for no instances message
 	.no-results-container {
 		align-self: center;

--- a/src/app/service-management/sm-slice-template-detail/sm-slice-template-detail.component.ts
+++ b/src/app/service-management/sm-slice-template-detail/sm-slice-template-detail.component.ts
@@ -67,6 +67,10 @@ export class SmSliceTemplateDetailComponent implements OnInit {
 		this.utilsService.copyToClipboard(value);
 	}
 
+	openRow(row) {
+		this.router.navigate([ `service-management/network-services/services/${ row.nsdRef }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html
+++ b/src/app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html
@@ -50,8 +50,8 @@
 	</div>
 
 	<div class="same-row">
-		<mat-form-field *ngIf="detail['nsName']" class="left-column">
-			<input matInput placeholder="Service Name" value="{{ detail['nsName'] }}" disabled
+		<mat-form-field *ngIf="detail['nsName']" class="left-column" (click)="openService()">
+			<input matInput class="opening-item" placeholder="Service Name" value="{{ detail['nsName'] }}" disabled
 				i18n-placeholder="@@serviceNamePlaceholder" />
 		</mat-form-field>
 

--- a/src/app/service-platform/runtime-policy-detail/runtime-policy-detail.component.ts
+++ b/src/app/service-platform/runtime-policy-detail/runtime-policy-detail.component.ts
@@ -131,6 +131,10 @@ export class RuntimePolicyDetailComponent implements OnInit {
 		this.utilsService.copyToClipboard(value);
 	}
 
+	openService() {
+		this.router.navigate([ `service-platform/network-services/${ this.detail[ 'nsUUID' ] }` ]);
+	}
+
 	close() {
 		this.router.navigate([ 'service-platform/policies/runtime-policies' ]);
 	}

--- a/src/app/service-platform/sla-template-detail/sla-template-detail.component.html
+++ b/src/app/service-platform/sla-template-detail/sla-template-detail.component.html
@@ -40,8 +40,8 @@
 	</div>
 
 	<div class="same-row">
-		<app-select class="left-column" *ngIf="detail['nsName']" placeholder="Network Service" [list]="[ detail.nsName ]"
-			[value]="detail.nsName" [disabled]="true" i18n-placeholder="@@nsPlaceholder">
+		<app-select class="left-column opening-item" *ngIf="detail['nsName']" placeholder="Network Service" [list]="[ detail.nsName ]"
+			[value]="detail.nsName" [disabled]="true" (click)="openService()" i18n-placeholder="@@nsPlaceholder">
 		</app-select>
 
 		<app-calendar *ngIf="detail['expirationDate']" class="right-column" placeholder="Expiration Date" [value]="detail['expirationDate']"

--- a/src/app/service-platform/sla-template-detail/sla-template-detail.component.ts
+++ b/src/app/service-platform/sla-template-detail/sla-template-detail.component.ts
@@ -78,6 +78,10 @@ export class SlaTemplateDetailComponent implements OnInit {
 		return !this.closed && (this.detail[ 'license' ] || this.detail[ 'licenseExpirationDate' ] || this.detail[ 'licenseInstances' ]);
 	}
 
+	openService() {
+		this.router.navigate([ `service-platform/network-services/${ this.detail[ 'ns' ] }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-platform/sp-functions-detail/sp-functions-detail.component.html
+++ b/src/app/service-platform/sp-functions-detail/sp-functions-detail.component.html
@@ -19,6 +19,14 @@
 </div>
 
 <form class="detail">
+	<mat-form-field *ngIf="detail['uuid']" class="left-column">
+		<input matInput placeholder="Function id" value="{{ detail['uuid'] }}" disabled i18n-placeholder="@@functionIDPlaceholder" />
+		<button mat-button matTooltip="Copy" class="icon-button-shadow" matSuffix (click)="copyToClipboard(detail['uuid'])"
+			i18n-matTooltip="@@copy">
+			<i class="wui wui-copy-alt"></i>
+		</button>
+	</mat-form-field>
+
 	<mat-form-field class="vendor" *ngIf="detail['vendor']">
 		<input matInput placeholder="Vendor" value="{{ detail['vendor'] }}" disabled i18n-placeholder="@@vendorPlaceholder" />
 	</mat-form-field>

--- a/src/app/service-platform/sp-functions-detail/sp-functions-detail.component.scss
+++ b/src/app/service-platform/sp-functions-detail/sp-functions-detail.component.scss
@@ -1,27 +1,27 @@
 @import "../../../constants.scss";
 app-sp-functions-detail {
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  flex: 1 1;
-  position: absolute;
-  align-items: center;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  left: 0;
-  background-color: $basic-background-color;
-  > * {
-    flex: 0 0 auto;
-  }
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1;
+	position: absolute;
+	align-items: center;
+	top: 0;
+	bottom: 0;
+	right: 0;
+	left: 0;
+	background-color: $basic-background-color;
+	> * {
+		flex: 0 0 auto;
+	}
 
-  .detail {
-    width: 65%;
-    align-items: center;
-    margin-bottom: 20px;
+  	.detail {
+		width: 55vw;
+		margin-bottom: 5vh;
 
-    .mat-form-field {
-      width: 100%;
-    }
-  }
+		.left-column {
+			width: 25vw;
+			margin-right: 40px;
+		}
+  	}
 }

--- a/src/app/service-platform/sp-functions-detail/sp-functions-detail.component.ts
+++ b/src/app/service-platform/sp-functions-detail/sp-functions-detail.component.ts
@@ -47,6 +47,10 @@ export class SpFunctionsDetailComponent implements OnInit {
 		}
 	}
 
+	copyToClipboard(value) {
+		this.utilsService.copyToClipboard(value);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html
+++ b/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html
@@ -22,8 +22,8 @@
 	<mat-form-field class="vendor" *ngIf="detail['vendor']">
 		<input matInput placeholder="Vendor" value="{{ detail['vendor'] }}" disabled i18n-placehoder="@@vendorPlaceholder" />
 	</mat-form-field>
-	<mat-form-field class="serviceId" *ngIf="detail['serviceID']">
-		<input matInput placeholder="Service id" value="{{ detail['serviceID'] }}" disabled i18n-placeholder="@@serviceIDPlaceholder" />
+	<mat-form-field class="serviceId" *ngIf="detail['uuid']">
+		<input matInput placeholder="Service id" value="{{ detail['uuid'] }}" disabled i18n-placeholder="@@serviceIDPlaceholder" />
 	</mat-form-field>
 	<mat-form-field class="status" *ngIf="detail['status']">
 		<input matInput placeholder="Status" value="{{ detail['status'] }}" disabled i18n-placeholder="@@statusPlaceholder" />

--- a/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html
+++ b/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html
@@ -19,22 +19,31 @@
 </div>
 
 <form class="detail">
+	<mat-form-field *ngIf="detail['uuid']" class="left-column">
+		<input matInput placeholder="Service id" value="{{ detail['uuid'] }}" disabled i18n-placeholder="@@serviceIDPlaceholder" />
+		<button mat-button matTooltip="Copy" class="icon-button-shadow" matSuffix (click)="copyToClipboard(detail['uuid'])"
+			i18n-matTooltip="@@copy">
+			<i class="wui wui-copy-alt"></i>
+		</button>
+	</mat-form-field>
+
 	<mat-form-field class="vendor" *ngIf="detail['vendor']">
 		<input matInput placeholder="Vendor" value="{{ detail['vendor'] }}" disabled i18n-placehoder="@@vendorPlaceholder" />
 	</mat-form-field>
-	<mat-form-field class="serviceId" *ngIf="detail['uuid']">
-		<input matInput placeholder="Service id" value="{{ detail['uuid'] }}" disabled i18n-placeholder="@@serviceIDPlaceholder" />
-	</mat-form-field>
+
 	<mat-form-field class="status" *ngIf="detail['status']">
 		<input matInput placeholder="Status" value="{{ detail['status'] }}" disabled i18n-placeholder="@@statusPlaceholder" />
 	</mat-form-field>
+
 	<mat-form-field class="type" *ngIf="detail['type']">
 		<input matInput placeholder="Type" value="{{ detail['type'] }}" disabled i18n-placeholder="@@typePlaceholder" />
 	</mat-form-field>
+
 	<mat-form-field class="time-form-field" *ngIf="detail['updatedAt']">
 		<input matInput placeholder="Updated at" value="Last update: {{ detail['updatedAt'] }}" disabled
 			i18n-placeholder="@@updatedAtPlaceholder" />
 	</mat-form-field>
+
 	<div class="description" *ngIf="detail['description']">
 		<h4 class="title4" i18n="description">Description</h4>
 		<span class="content">
@@ -44,8 +53,7 @@
 
 	<div class="vnf" *ngIf="detail['vnf']">
 		<h2 class="title2" i18n="@@vnfs">VNFs</h2>
-		<span class="message" *ngIf="detail['vnf'].length == 0" i18n="@@noVNFToDisplayMsg">There are no virtual network
-			functions to display</span>
+
 		<table mat-table *ngIf="detail['vnf'].length > 0" [dataSource]="detail['vnf']">
 			<ng-container matColumnDef="id">
 				<th mat-header-cell *matHeaderCellDef i18n="@@id">ID</th>
@@ -70,6 +78,12 @@
 			<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
 			<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 		</table>
+
+		<div *ngIf="canShowVNFs()" class="no-results-container">
+			<div class="no-results-line"></div>
+			<span class="no-results-text" i18n="@@noResultsToDisplay">No results to display</span>
+			<div class="no-results-line"></div>
+		</div>
 	</div>
 </form>
 

--- a/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.scss
+++ b/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.scss
@@ -1,58 +1,62 @@
 @import "../../../constants.scss";
 app-sp-network-services-detail {
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  flex: 1 1;
-  position: absolute;
-  align-items: center;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  left: 0;
-  background-color: $basic-background-color;
-  > * {
-    flex: 0 0 auto;
-  }
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1;
+	position: absolute;
+	align-items: center;
+	top: 0;
+	bottom: 0;
+	right: 0;
+	left: 0;
+	background-color: $basic-background-color;
+	> * {
+		flex: 0 0 auto;
+	}
 
-  .detail {
-    width: 65%;
-    margin-bottom: 20px;
+  	.detail {
+		width: 55vw;
+		margin-bottom: 5vh;
 
-    .mat-form-field {
-      width: 100%;
-    }
+		.left-column {
+			width: 25vw;
+			margin-right: 40px;
+		}
 
-    .description {
-      margin-bottom: 50px;
-    }
+		.description {
+			margin-bottom: 50px;
+		}
 
-    .title3 {
-      font-size: 24px;
-    }
+		.title3 {
+			font-size: 24px;
+		}
 
-    .message {
-      color: $secondary-font-color-light;
-    }
+		table {
+			width: 100%;
+			margin-bottom: 50px;
 
-    table {
-      width: 100%;
-      margin-bottom: 50px;
-    }
+			tr.mat-row {
+				background-image: linear-gradient(
+					to right,
+					$basic-background-color 0%,
+					$table-underline-color 0%,
+					$table-underline-color 99%,
+					$basic-background-color 99%,
+					$basic-background-color 100%
+				);
+			}
 
-    tr.mat-row {
-      background-image: linear-gradient(
-        to right,
-        $basic-background-color 0%,
-        $table-underline-color 0%,
-        $table-underline-color 99%,
-        $basic-background-color 99%,
-        $basic-background-color 100%
-      );
-    }
+			td.mat-cell {
+				cursor: auto;
+			}
+		}
 
-    td.mat-cell {
-      cursor: auto;
-    }
-  }
+		// Styles for no vnfs message
+		.no-results-container {
+			align-self: center;
+			width: 100%;
+			margin-top: 7vh;
+		}
+ 	}
 }

--- a/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.ts
+++ b/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.ts
@@ -29,24 +29,21 @@ export class SpNetworkServicesDetailComponent implements OnInit {
 		});
 	}
 
-	requestNetworkService(uuid) {
+	async requestNetworkService(uuid) {
 		this.loading = true;
+		const response = await this.commonService.getOneNetworkService('sp', uuid);
 
-		this.commonService
-			.getOneNetworkService('sp', uuid)
-			.then(response => {
-				this.loading = false;
-				this.detail = response;
+		this.loading = false;
+		if (response) {
+			this.detail = response;
 
-				if (this.detail[ 'vnf' ].lenght < 1) {
-					this.detail[ 'vnf' ] = [];
-				}
-			})
-			.catch(err => {
-				this.loading = false;
-				this.utilsService.openSnackBar(err, '');
-				this.close();
-			});
+			if (this.detail[ 'vnf' ].lenght < 1) {
+				this.detail[ 'vnf' ] = [];
+			}
+		} else {
+			this.utilsService.openSnackBar('Unable to fetch the network service', '');
+			this.close();
+		}
 	}
 
 	close() {

--- a/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.ts
+++ b/src/app/service-platform/sp-network-services-detail/sp-network-services-detail.component.ts
@@ -46,6 +46,14 @@ export class SpNetworkServicesDetailComponent implements OnInit {
 		}
 	}
 
+	copyToClipboard(value) {
+		this.utilsService.copyToClipboard(value);
+	}
+
+	canShowVNFs() {
+		return (!this.detail[ 'vnf' ] || !this.detail[ 'vnf' ].length) && !this.loading;
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-platform/sp-network-services/sp-network-services.component.html
+++ b/src/app/service-platform/sp-network-services/sp-network-services.component.html
@@ -30,7 +30,7 @@
 	</ng-container>
 
 	<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-	<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openNetworkService(row.serviceId)"></tr>
+	<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openNetworkService(row.uuid)"></tr>
 </table>
 
 <div *ngIf="(!networkServices || !networkServices.length) && !loading" class="no-results-container">

--- a/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.html
+++ b/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.html
@@ -19,6 +19,14 @@
 </div>
 
 <form class="detail">
+	<mat-form-field *ngIf="detail['uuid']" class="left-column">
+		<input matInput placeholder="Package ID" value="{{ detail['uuid'] }}" disabled i18n-placeholder="@@packageIDPlaceholder" />
+		<button mat-button matTooltip="Copy" class="icon-button-shadow" matSuffix (click)="copyToClipboard(detail['uuid'])"
+			i18n-matTooltip="@@copy">
+			<i class="wui wui-copy-alt"></i>
+		</button>
+	</mat-form-field>
+
 	<mat-form-field class="vendor" *ngIf="detail['vendor']">
 		<input matInput placeholder="Vendor" value="{{ detail['vendor'] }}" disabled i18n-placeholder="@@vendorPlaceholder" />
 	</mat-form-field>

--- a/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.html
+++ b/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.html
@@ -53,7 +53,7 @@
 		</ng-container>
 
 		<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-		<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+		<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow('service', row)"></tr>
 	</table>
 </div>
 
@@ -81,7 +81,7 @@
 		</ng-container>
 
 		<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-		<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+		<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow('function', row)"></tr>
 	</table>
 </div>
 

--- a/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.scss
+++ b/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.scss
@@ -32,26 +32,22 @@ app-sp-packages-detail {
 
     table {
       	width: 95%;
-    }
 
-    tr.mat-row {
-		background-image: linear-gradient(
-			to right,
-			$basic-background-color 0%,
-			$table-underline-color 0%,
-			$table-underline-color 100%,
-			$basic-background-color 100%,
-			$basic-background-color 100%
-		);
-    }
+		tr.mat-row {
+			background-image: linear-gradient(
+				to right,
+				$basic-background-color 0%,
+				$table-underline-color 0%,
+				$table-underline-color 100%,
+				$basic-background-color 100%,
+				$basic-background-color 100%
+			);
+		}
 
-    td.mat-cell {
-      	cursor: auto;
-    }
-
-    .mat-cell:nth-child(1),
-    .mat-header-cell:nth-child(1) {
-      	width: 30%;
+		.mat-cell:nth-child(1),
+		.mat-header-cell:nth-child(1) {
+			width: 30%;
+		}
     }
 }
 

--- a/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.scss
+++ b/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.scss
@@ -18,6 +18,11 @@ app-sp-packages-detail {
 	form {
 		width: 55vw;
 		margin-bottom: 5vh;
+
+		.left-column {
+			width: 25vw;
+			margin-right: 40px;
+		}
 	}
 
 	.vnf,

--- a/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.ts
+++ b/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.ts
@@ -56,6 +56,14 @@ export class SpPackagesDetailComponent implements OnInit {
 		return this.detail[ 'vnf' ] && this.detail[ 'vnf' ].length;
 	}
 
+	openRow(section, row) {
+		if (section === 'service') {
+			this.router.navigate([ `service-platform/network-services/${ row.uuid }` ]);
+		} else if (section === 'function') {
+			this.router.navigate([ `service-platform/functions/${ row.uuid }` ]);
+		}
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.ts
+++ b/src/app/service-platform/sp-packages-detail/sp-packages-detail.component.ts
@@ -64,6 +64,10 @@ export class SpPackagesDetailComponent implements OnInit {
 		}
 	}
 
+	copyToClipboard(value) {
+		this.utilsService.copyToClipboard(value);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.html
+++ b/src/app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.html
@@ -102,7 +102,7 @@
 	</ng-container>
 
 	<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-	<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+	<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow(row)"></tr>
 </table>
 
 <div *ngIf="(detail['services'] && !detail['services'].length) && !loading" class="no-results-container">
@@ -113,7 +113,7 @@
 
 <h2 *ngIf="detail['sliceVirtualLinks']" class="title2" i18n="@@sliceVirtualLinks">Slice virtual links</h2>
 
-<table *ngIf="detail['sliceVirtualLinks']" mat-table [dataSource]="detail['sliceVirtualLinks']">
+<table *ngIf="detail['sliceVirtualLinks']" class="no-opening-table" mat-table [dataSource]="detail['sliceVirtualLinks']">
 	<ng-container matColumnDef="networkName">
 		<th mat-header-cell *matHeaderCellDef i18n="@@networkName">Network Name</th>
 		<td mat-cell *matCellDef="let element">{{ element.networkName }}</td>

--- a/src/app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.scss
+++ b/src/app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.scss
@@ -38,29 +38,29 @@ app-sp-slice-template-detail {
 	table {
 		width: 55vw;
 		margin-bottom: 50px;
+
+		tr.mat-row {
+			background-image: linear-gradient(
+				to right,
+				$basic-background-color 0%,
+				$table-underline-color 0%,
+				$table-underline-color 99%,
+				$basic-background-color 99%,
+				$basic-background-color 100%
+				);
+		}
+			
+		&.no-opening-table td.mat-cell {
+			cursor: auto;
+		}
+
+		.mat-cell:nth-child(6),
+		.mat-header-cell:nth-child(6) {
+			width: 16%;
+			padding-right: 0;
+		}
 	}
 	
-	tr.mat-row {
-		background-image: linear-gradient(
-			to right,
-			$basic-background-color 0%,
-			$table-underline-color 0%,
-			$table-underline-color 99%,
-			$basic-background-color 99%,
-			$basic-background-color 100%
-			);
-	}
-		
-	td.mat-cell {
-		cursor: auto;
-	}
-
-	.mat-cell:nth-child(6),
-	.mat-header-cell:nth-child(6) {
-		width: 16%;
-		padding-right: 0;
-	}
-
 	// Styles for no instances message
 	.no-results-container {
 		align-self: center;

--- a/src/app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.ts
+++ b/src/app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.ts
@@ -72,6 +72,10 @@ export class SpSliceTemplateDetailComponent implements OnInit {
 		this.utilsService.copyToClipboard(value);
 	}
 
+	openRow(row) {
+		this.router.navigate([ `service-platform/network-services/${ row.nsdRef }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/settings/endpoint-list/endpoint-list.component.scss
+++ b/src/app/settings/endpoint-list/endpoint-list.component.scss
@@ -11,16 +11,20 @@ app-endpoint-list {
     
     table {
         width: 95%;
-    }
     
-    tr.mat-row {
-        background-image: linear-gradient(
-          to right,
-          $basic-background-color 0%,
-          $table-underline-color 0%,
-          $table-underline-color 100%,
-          $basic-background-color 100%,
-          $basic-background-color 100%
-        );
+		tr.mat-row {
+			background-image: linear-gradient(
+			to right,
+			$basic-background-color 0%,
+			$table-underline-color 0%,
+			$table-underline-color 100%,
+			$basic-background-color 100%,
+			$basic-background-color 100%
+			);
+		}
+
+		td.mat-cell {
+        	cursor: auto;
+      	}
     }
 }

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -82,7 +82,7 @@ export class CommonService {
 				updatedAt: response[ 'updated_at' ],
 				vendor: response[ 'pd' ][ 'vendor' ],
 				version: response[ 'pd' ][ 'version' ],
-				status: response[ 'status' ],
+				status: response[ 'status' ]
 			};
 
 			return Object.assign({ }, packageData, content);
@@ -474,11 +474,11 @@ export class CommonService {
 			sonataPlatforms: platforms[ 'SONATA' ] || this.unknown,
 			osmPlatforms: platforms[ 'OSM' ] || this.unknown,
 			onapPlatforms: platforms[ 'ONAP' ] || this.unknown,
-			testsExecuted: await this.getTestsNumber('executed') || this.unknown,
-			testsInProgress: await this.getTestsNumber('in_progress') || this.unknown,
-			testsWaitingForConfirmation: await this.getTestsNumber('waiting_for_confirmation') || this.unknown,
-			testsScheduled: await this.getTestsNumber('scheduled') || this.unknown,
-			testsFailed: await this.getTestsNumber('error') || this.unknown
+			testsCompleted: await this.getTestsNumber('COMPLETED') || this.unknown,
+			testsInProgress: await this.getTestsNumber('STARTING') || this.unknown,
+			testsWaitingForConfirmation: await this.getTestsNumber('WAITING_FOR_CONFIRMATION') || this.unknown,
+			testsScheduled: await this.getTestsNumber('SCHEDULED') || this.unknown,
+			testsFailed: await this.getTestsNumber('ERROR') || this.unknown
 		};
 	}
 

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -367,7 +367,7 @@ export class CommonService {
 					vnf: components
 				};
 			} else {
-				return { };
+				return null;
 			}
 		} catch (error) {
 			if (error.status === 401 && error.statusText === 'Unauthorized') {

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -148,8 +148,8 @@ export class CommonService {
 
 		try {
 			const response = await this.http.get(url, { headers: headers }).toPromise();
-			return response instanceof Array ?
-				response.filter(funct => funct.platform.toLowerCase() === '5gtango')
+			if (response instanceof Array) {
+				const tango = response.filter(funct => funct.platform.toLowerCase() === '5gtango')
 					.map(item => {
 						return {
 							uuid: item.uuid,
@@ -157,9 +157,23 @@ export class CommonService {
 							vendor: item.vnfd.vendor,
 							status: item.status,
 							version: item.vnfd.version,
-							type: 'public'
 						};
-					}) : [];
+					});
+
+				const osm = response.filter(funct => funct.platform.toLowerCase() === 'osm')
+					.map(item => {
+						return {
+							uuid: item.uuid,
+							name: item.vnfd[ 'vnfd:vnfd-catalog' ].vnfd.name,
+							vendor: item.vnfd[ 'vnfd:vnfd-catalog' ].vnfd.vendor,
+							status: item.status,
+							version: item.vnfd[ 'vnfd:vnfd-catalog' ].vnfd.version,
+						};
+					});
+
+				return tango.concat(osm);
+			}
+			return [];
 		} catch (error) {
 			if (error.status === 401 && error.statusText === 'Unauthorized') {
 				this.utilsService.launchUnauthorizedError();
@@ -271,15 +285,27 @@ export class CommonService {
 
 		try {
 			const response = await this.http.get(url, { headers: headers }).toPromise();
-			return response instanceof Array ?
-				response.filter(ns => ns.platform.toLowerCase() === '5gtango')
+			if (response instanceof Array) {
+				const tango = response.filter(ns => ns.platform.toLowerCase() === '5gtango')
 					.map(item => ({
 						uuid: item.uuid,
 						name: item.nsd.name,
 						vendor: item.nsd.vendor,
 						version: item.nsd.version,
 						status: item.status
-					})) : [];
+					}));
+
+				const osm = response.filter(ns => ns.platform.toLowerCase() === 'osm')
+					.map(item => ({
+						uuid: item.uuid,
+						name: item.nsd[ 'nsd:nsd-catalog' ].nsd.name,
+						vendor: item.nsd[ 'nsd:nsd-catalog' ].nsd.vendor,
+						version: item.nsd[ 'nsd:nsd-catalog' ].nsd.version,
+						status: item.status
+					}));
+				return tango.concat(osm);
+			}
+			return [];
 		} catch (error) {
 			if (error.status === 401 && error.statusText === 'Unauthorized') {
 				this.utilsService.launchUnauthorizedError();

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -101,19 +101,19 @@ export class CommonService {
 		const tests = [];
 
 		content.forEach(item => {
-			if (item[ 'content-type' ] === 'application/vnd.5gtango.nsd') {
+			if (item[ 'content-type' ].endsWith('.nsd')) {
 				ns.push({
 					vendor: item.id.vendor,
 					name: item.id.name,
 					version: item.id.version
 				});
-			} else if (item[ 'content-type' ] === 'application/vnd.5gtango.vnfd') {
+			} else if (item[ 'content-type' ].endsWith('.vnfd')) {
 				vnf.push({
 					vendor: item.id.vendor,
 					name: item.id.name,
 					version: item.id.version
 				});
-			} else if (item[ 'content-type' ] === 'application/vnd.5gtango.tstd') {
+			} else if (item[ 'content-type' ].endsWith('.tstd')) {
 				tests.push({
 					vendor: item.id.vendor,
 					name: item.id.name,

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -465,6 +465,7 @@ export class CommonService {
 				services: response[ 'nstd' ] ? response[ 'nstd' ][ 'slice_ns_subnets' ].map(item => {
 					return {
 						uuid: item[ 'id' ],
+						nsdRef: item[ 'nsd-ref' ],
 						nsdName: item[ 'nsd-name' ],
 						nsdVendor: item[ 'nsd-vendor' ],
 						nsdVersion: item[ 'nsd-version' ],

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -276,7 +276,6 @@ export class CommonService {
 					.map(item => ({
 						uuid: item.uuid,
 						name: item.nsd.name,
-						serviceId: item.uuid,
 						vendor: item.nsd.vendor,
 						version: item.nsd.version,
 						status: item.status

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -103,18 +103,21 @@ export class CommonService {
 		content.forEach(item => {
 			if (item[ 'content-type' ].endsWith('.nsd')) {
 				ns.push({
+					uuid: item.uuid,
 					vendor: item.id.vendor,
 					name: item.id.name,
 					version: item.id.version
 				});
 			} else if (item[ 'content-type' ].endsWith('.vnfd')) {
 				vnf.push({
+					uuid: item.uuid,
 					vendor: item.id.vendor,
 					name: item.id.name,
 					version: item.id.version
 				});
 			} else if (item[ 'content-type' ].endsWith('.tstd')) {
 				tests.push({
+					uuid: item.uuid,
 					vendor: item.id.vendor,
 					name: item.id.name,
 					version: item.id.version

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -331,8 +331,6 @@ export class CommonService {
 			return response.hasOwnProperty('nsd') ?
 				{
 					uuid: response[ 'uuid' ],
-					// duplicated
-					serviceID: response[ 'uuid' ],
 					platform: response[ 'platform' ],
 					status: response[ 'status' ],
 					updatedAt: response[ 'updated_at' ],

--- a/src/app/shared/services/common/common.service.ts
+++ b/src/app/shared/services/common/common.service.ts
@@ -149,16 +149,17 @@ export class CommonService {
 		try {
 			const response = await this.http.get(url, { headers: headers }).toPromise();
 			return response instanceof Array ?
-				response.map(item => {
-					return {
-						uuid: item.uuid,
-						name: item.vnfd.name,
-						vendor: item.vnfd.vendor,
-						status: item.status,
-						version: item.vnfd.version,
-						type: 'public'
-					};
-				}) : [];
+				response.filter(funct => funct.platform.toLowerCase() === '5gtango')
+					.map(item => {
+						return {
+							uuid: item.uuid,
+							name: item.vnfd.name,
+							vendor: item.vnfd.vendor,
+							status: item.status,
+							version: item.vnfd.version,
+							type: 'public'
+						};
+					}) : [];
 		} catch (error) {
 			if (error.status === 401 && error.statusText === 'Unauthorized') {
 				this.utilsService.launchUnauthorizedError();

--- a/src/app/validation-and-verification/test-plan-list/test-plan-list.component.html
+++ b/src/app/validation-and-verification/test-plan-list/test-plan-list.component.html
@@ -9,7 +9,7 @@
 	</button>
 </div>
 
-<table mat-table [dataSource]="dataSource" matSort>
+<table mat-table [dataSource]="dataSource" matSort matSortActive="updatedAt" matSortDirection="desc">
 	<ng-container matColumnDef="testName">
 		<th mat-header-cell *matHeaderCellDef i18n="@@testName">Test name</th>
 		<td mat-cell *matCellDef="let element">{{ element.testName }}</td>

--- a/src/app/validation-and-verification/test-plan-list/test-plan-list.component.ts
+++ b/src/app/validation-and-verification/test-plan-list/test-plan-list.component.ts
@@ -59,23 +59,11 @@ export class TestPlanListComponent implements OnInit {
 
 		this.loading = false;
 		if (testPlans) {
-			this.dataSource.data = this.sortTestPlans(testPlans);
+			this.dataSource.data = testPlans;
 			this.dataSource.sort = this.sort;
 		} else {
 			this.utilsService.openSnackBar('Unable to fetch any test plan', '');
 		}
-	}
-
-	private sortTestPlans(testPlans) {
-		return testPlans.sort((a) => {
-			const status = a.status.toUpperCase();
-
-			if (status !== 'COMPLETED') {
-				return -1;
-			} else {
-				return 1;
-			}
-		});
 	}
 
 	async confirmExecution(plan) {

--- a/src/app/validation-and-verification/test-plan/test-plan.component.html
+++ b/src/app/validation-and-verification/test-plan/test-plan.component.html
@@ -31,8 +31,9 @@
 			</button>
 		</mat-form-field>
 
-		<mat-form-field *ngIf="testPlan['testName']">
-			<input matInput placeholder="Test" value="{{ testPlan['testName'] }}" disabled i18n-placeholder="@@testPlaceholder" />
+		<mat-form-field *ngIf="testPlan['testName']" (click)="openTest()">
+			<input matInput class="opening-item" placeholder="Test" value="{{ testPlan['testName'] }}" disabled
+				i18n-placeholder="@@testPlaceholder" />
 		</mat-form-field>
 	</div>
 
@@ -46,8 +47,9 @@
 			</button>
 		</mat-form-field>
 
-		<mat-form-field *ngIf="testPlan['serviceName']">
-			<input matInput placeholder="Service" value="{{ testPlan['serviceName'] }}" disabled i18n-placeholder="@@servicePlaceholder" />
+		<mat-form-field *ngIf="testPlan['serviceName']" (click)="openService()">
+			<input matInput class="opening-item" placeholder="Service" value="{{ testPlan['serviceName'] }}" disabled
+				i18n-placeholder="@@servicePlaceholder" />
 		</mat-form-field>
 	</div>
 

--- a/src/app/validation-and-verification/test-plan/test-plan.component.ts
+++ b/src/app/validation-and-verification/test-plan/test-plan.component.ts
@@ -99,6 +99,14 @@ export class TestPlanComponent implements OnInit {
 		return JSON.stringify(json);
 	}
 
+	openService() {
+		this.router.navigate([ `validation-and-verification/network-services/${ this.testPlan[ 'serviceUUID' ] }` ]);
+	}
+
+	openTest() {
+		this.router.navigate([ `validation-and-verification/tests/${ this.testPlan[ 'testUUID' ] }` ]);
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/validation-and-verification/tests-detail/tests-detail.component.html
+++ b/src/app/validation-and-verification/tests-detail/tests-detail.component.html
@@ -84,7 +84,7 @@
 		</ng-container>
 
 		<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-		<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+		<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow('service', row)"></tr>
 	</table>
 
 	<div *ngIf="(!relatedServices || !relatedServices.length) && !loading" class="no-results-container">
@@ -114,7 +114,7 @@
 		</ng-container>
 
 		<tr mat-header-row *matHeaderRowDef="displayedColumnsTestPlans"></tr>
-		<tr mat-row *matRowDef="let row; columns: displayedColumnsTestPlans"></tr>
+		<tr mat-row *matRowDef="let row; columns: displayedColumnsTestPlans" (click)="openRow('testPlan', row)"></tr>
 	</table>
 
 	<div *ngIf="(!testPlans || !testPlans.length) && !loading" class="no-results-container">

--- a/src/app/validation-and-verification/tests-detail/tests-detail.component.scss
+++ b/src/app/validation-and-verification/tests-detail/tests-detail.component.scss
@@ -67,10 +67,6 @@ app-tests-detail {
 				);
 			}
 		}
-
-		td.mat-cell {
-			cursor: auto;
-		}
 	}
 
 	// Styles for no instances message

--- a/src/app/validation-and-verification/tests-detail/tests-detail.component.ts
+++ b/src/app/validation-and-verification/tests-detail/tests-detail.component.ts
@@ -93,6 +93,14 @@ export class TestsDetailComponent implements OnInit {
 		this.utilsService.copyToClipboard(value);
 	}
 
+	openRow(section, row) {
+		if (section === 'service') {
+			this.router.navigate([ `validation-and-verification/network-services/${ row.uuid }` ]);
+		} else if (section === 'testPlan') {
+			this.router.navigate([ `validation-and-verification/test-plans/${ row.uuid }` ]);
+		}
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/app/validation-and-verification/validation-and-verification.service.ts
+++ b/src/app/validation-and-verification/validation-and-verification.service.ts
@@ -97,14 +97,31 @@ export class ValidationAndVerificationPlatformService {
 
 		try {
 			const response = await this.http.get(url, { headers: headers }).toPromise();
-			return response instanceof Array ?
-				response.map(item => {
-					return {
-						vendor: item.nsd.vendor,
-						name: item.nsd.name,
-						version: item.nsd.version
-					};
-				}) : [];
+			if (response instanceof Array) {
+				const tango = response.filter(ns => ns.platform.toLowerCase() === '5gtango')
+					.map(item => {
+						return {
+							uuid: item.uuid,
+							vendor: item.nsd.vendor,
+							name: item.nsd.name,
+							version: item.nsd.version
+						};
+					});
+
+				const osm = response.filter(ns => ns.platform.toLowerCase() === 'osm')
+					.map(item => {
+						return {
+							uuid: item.uuid,
+							vendor: item.nsd[ 'nsd:nsd-catalog' ][ 'nsd' ].vendor,
+							name: item.nsd[ 'nsd:nsd-catalog' ][ 'nsd' ].name,
+							version: item.nsd[ 'nsd:nsd-catalog' ][ 'nsd' ].version
+						};
+					});
+
+				return tango.concat(osm);
+			}
+
+			return [];
 		} catch (error) {
 			if (error.status === 401 && error.statusText === 'Unauthorized') {
 				this.utilsService.launchUnauthorizedError();

--- a/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.html
+++ b/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.html
@@ -19,6 +19,14 @@
 </div>
 
 <form class="detail">
+	<mat-form-field *ngIf="detail['uuid']" class="left-column">
+		<input matInput placeholder="Package ID" value="{{ detail['uuid'] }}" disabled i18n-placeholder="@@packageIDPlaceholder" />
+		<button mat-button matTooltip="Copy" class="icon-button-shadow" matSuffix (click)="copyToClipboard(detail['uuid'])"
+			i18n-matTooltip="@@copy">
+			<i class="wui wui-copy-alt"></i>
+		</button>
+	</mat-form-field>
+
 	<mat-form-field *ngIf="detail['vendor']">
 		<input matInput placeholder="Vendor" value="{{ detail['vendor'] }}" disabled i18n-placeholder="@@vendorPlaceholder" />
 	</mat-form-field>

--- a/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.html
+++ b/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.html
@@ -58,7 +58,7 @@
 		</ng-container>
 
 		<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-		<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+		<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow('service', row)"></tr>
 	</table>
 </div>
 
@@ -69,7 +69,7 @@
 		There are no virtual network functions to display
 	</span>
 
-	<table mat-table *ngIf="canShowVNF()" [dataSource]="detail['vnf']">
+	<table class="no-opening-table" mat-table *ngIf="canShowVNF()" [dataSource]="detail['vnf']">
 		<ng-container matColumnDef="vendor">
 			<th mat-header-cell *matHeaderCellDef i18n="@@vendor">Vendor</th>
 			<td mat-cell *matCellDef="let element">{{ element.vendor }}</td>
@@ -114,7 +114,7 @@
 		</ng-container>
 
 		<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-		<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+		<tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openRow('test', row)"></tr>
 	</table>
 </div>
 

--- a/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.scss
+++ b/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.scss
@@ -33,26 +33,24 @@ app-vnv-packages-detail {
 
     table {
       	width: 95%;
-    }
 
-    tr.mat-row {
-		background-image: linear-gradient(
-			to right,
-			$basic-background-color 0%,
-			$table-underline-color 0%,
-			$table-underline-color 100%,
-			$basic-background-color 100%,
-			$basic-background-color 100%
-		);
-    }
+		&.no-opening-table td.mat-cell {
+			cursor: auto;
+		}
 
-    td.mat-cell {
-      	cursor: auto;
+		tr.mat-row {
+			background-image: linear-gradient(
+				to right,
+				$basic-background-color 0%,
+				$table-underline-color 0%,
+				$table-underline-color 100%,
+				$basic-background-color 100%,
+				$basic-background-color 100%
+			);
+    	}
+		.mat-cell:nth-child(1),
+		.mat-header-cell:nth-child(1) {
+			width: 30%;
+		}
     }
-
-    .mat-cell:nth-child(1),
-    .mat-header-cell:nth-child(1) {
-      	width: 30%;
-    }
-  
 }

--- a/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.scss
+++ b/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.scss
@@ -18,6 +18,11 @@ app-vnv-packages-detail {
 	form {
 		width: 55vw;
 		margin-bottom: 5vh;
+
+		.left-column {
+			width: 25vw;
+			margin-right: 40px;
+		}
 	}
 
     .vnf,

--- a/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.ts
+++ b/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.ts
@@ -60,6 +60,10 @@ export class VnvPackagesDetailComponent implements OnInit {
 		return this.detail[ 'tests' ] && this.detail[ 'tests' ].length;
 	}
 
+	copyToClipboard(value) {
+		this.utilsService.copyToClipboard(value);
+	}
+
 	openRow(section, row) {
 		if (section === 'service') {
 			this.router.navigate([ `validation-and-verification/network-services/${ row.uuid }` ]);

--- a/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.ts
+++ b/src/app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.ts
@@ -60,6 +60,14 @@ export class VnvPackagesDetailComponent implements OnInit {
 		return this.detail[ 'tests' ] && this.detail[ 'tests' ].length;
 	}
 
+	openRow(section, row) {
+		if (section === 'service') {
+			this.router.navigate([ `validation-and-verification/network-services/${ row.uuid }` ]);
+		} else if (section === 'test') {
+			this.router.navigate([ `validation-and-verification/tests/${ row.uuid }` ]);
+		}
+	}
+
 	close() {
 		this.router.navigate([ '../' ], { relativeTo: this.route });
 	}

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -1683,8 +1683,8 @@
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="executed" datatype="html">
-        <source>Executed</source><target state="final">Executed</target>
+      <trans-unit id="completed" datatype="html">
+        <source>Completed</source><target state="final">Completed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/dashboard/dashboard.component.html</context>
           <context context-type="linenumber">172</context>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -186,11 +186,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">49</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">77</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -293,11 +293,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">54</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">82</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -428,11 +428,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -1293,7 +1293,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -2225,6 +2225,10 @@
           <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
           <context context-type="linenumber">24</context>
         </context-group>
@@ -2760,7 +2764,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
@@ -2917,7 +2921,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
@@ -3035,7 +3039,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">69</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
@@ -3096,7 +3100,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="noTestToDisplayMsg" datatype="html">
@@ -3125,6 +3129,13 @@
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="packageIDPlaceholder" datatype="html">
+        <source>Package ID</source><target state="final">Package ID</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="noVNFToDisplay" datatype="html">
         <source>
 		There are no virtual network functions to display
@@ -3133,7 +3144,7 @@
 	</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="typePlaceholder" datatype="html">

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -198,7 +198,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-list/runtime-policy-list.component.html</context>
@@ -305,7 +305,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">69</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -444,7 +444,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
@@ -635,6 +635,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
           <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
+          <context context-type="linenumber">84</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-list/runtime-policy-list.component.html</context>
@@ -2202,15 +2206,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">120</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">134</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/tests-detail/tests-detail.component.html</context>
@@ -2218,6 +2222,14 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/vnv-network-services-detail/vnv-network-services-detail.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
           <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
@@ -2551,7 +2563,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/tests/tests.component.html</context>
@@ -2574,7 +2586,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cancelExecution" datatype="html">
@@ -2585,7 +2597,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="rejectExecution" datatype="html">
@@ -2596,7 +2608,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="testPlanIDPlaceholder" datatype="html">
@@ -2635,7 +2647,7 @@
         <source>Service ID</source><target state="final">Service ID</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/vnv-network-services-detail/vnv-network-services-detail.component.html</context>
@@ -2643,7 +2655,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -2666,18 +2678,18 @@
         <source>Service</source><target state="final">Service</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="statusPlaceholder" datatype="html">
         <source>Status</source><target state="final">Status</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/tests-detail/tests-detail.component.html</context>
@@ -2693,11 +2705,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sla-agreement-detail/sla-agreement-detail.component.html</context>
@@ -2721,7 +2733,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/ns-instance-detail/ns-instance-detail.component.html</context>
@@ -2736,7 +2748,7 @@
         <source>Updated at</source><target state="final">Updated at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/vnv-network-services-detail/vnv-network-services-detail.component.html</context>
@@ -2752,11 +2764,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -2776,7 +2788,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/ns-instance-detail/ns-instance-detail.component.html</context>
@@ -2787,53 +2799,53 @@
         <source>Confirm the test plan as required</source><target state="final">Confirm the test plan as required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cancellExecutionTestPlan" datatype="html">
         <source>Cancel the execution of the test plan</source><target state="final">Cancel the execution of the test plan</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="confirmOrCancelExecutionTestPlan" datatype="html">
         <source>Confirm or cancel the execution of the test plan</source><target state="final">Confirm or cancel the execution of the test plan</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="results" datatype="html">
         <source>Results</source><target state="final">Results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">97</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="startedAtPlaceholder" datatype="html">
         <source>Started at</source><target state="final">Started at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="endedAtPlaceholder" datatype="html">
         <source>Ended at</source><target state="final">Ended at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="details" datatype="html">
         <source>Details</source><target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="createdBy" datatype="html">
@@ -2909,7 +2921,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -2967,7 +2979,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.html</context>
@@ -3027,7 +3039,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/sm-network-services-detail/sm-network-services-detail.component.html</context>
@@ -3048,10 +3060,6 @@
           <context context-type="sourcefile">app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.html</context>
           <context context-type="linenumber">68</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="id" datatype="html">
         <source>ID</source><target state="final">ID</target>
@@ -3061,7 +3069,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/sm-network-services-detail/sm-network-services-detail.component.html</context>
@@ -3132,24 +3140,31 @@
         <source>Type</source><target state="final">Type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="eec715de352a6b114713b30b640d319fa78207a0" datatype="html">
         <source>Description</source><target state="final">Description</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <note priority="1" from="description">description</note>
+      </trans-unit>
+      <trans-unit id="functionIDPlaceholder" datatype="html">
+        <source>Function id</source><target state="final">Function id</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="selectPolicyPlaceholder" datatype="html">
         <source>Select a policy</source><target state="final">Select a policy</target>
@@ -3297,7 +3312,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/ns-instance-detail/ns-instance-detail.component.html</context>
@@ -4469,7 +4484,7 @@
         <source>SLA ID</source><target state="final">SLA ID</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/license-detail/license-detail.component.html</context>
@@ -4480,7 +4495,7 @@
         <source>Error</source><target state="final">Error</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="networkServiceInstances" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1616,8 +1616,8 @@
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="executed" datatype="html">
-        <source>Executed</source>
+      <trans-unit id="completed" datatype="html">
+        <source>Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/dashboard/dashboard.component.html</context>
           <context context-type="linenumber">172</context>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -186,11 +186,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">49</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">77</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -293,11 +293,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">54</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">82</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -428,11 +428,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -1254,7 +1254,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
@@ -2156,6 +2156,10 @@
           <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
           <context context-type="linenumber">24</context>
         </context-group>
@@ -2690,7 +2694,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
@@ -2847,7 +2851,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
@@ -2965,7 +2969,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">69</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
@@ -3022,7 +3026,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="noTestToDisplayMsg" datatype="html">
@@ -3049,13 +3053,20 @@
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="packageIDPlaceholder" datatype="html">
+        <source>Package ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="noVNFToDisplay" datatype="html">
         <source>
 		There are no virtual network functions to display
 	</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-packages-detail/sp-packages-detail.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="typePlaceholder" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -198,7 +198,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-list/runtime-policy-list.component.html</context>
@@ -305,7 +305,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">69</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -444,7 +444,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
@@ -635,6 +635,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services/sp-network-services.component.html</context>
           <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
+          <context context-type="linenumber">84</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-list/runtime-policy-list.component.html</context>
@@ -2133,15 +2137,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">120</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">134</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/tests-detail/tests-detail.component.html</context>
@@ -2149,6 +2153,14 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/vnv-network-services-detail/vnv-network-services-detail.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
           <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
@@ -2481,7 +2493,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/tests/tests.component.html</context>
@@ -2504,7 +2516,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cancelExecution" datatype="html">
@@ -2515,7 +2527,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="rejectExecution" datatype="html">
@@ -2526,7 +2538,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="testPlanIDPlaceholder" datatype="html">
@@ -2565,7 +2577,7 @@
         <source>Service ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/vnv-network-services-detail/vnv-network-services-detail.component.html</context>
@@ -2573,7 +2585,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -2596,18 +2608,18 @@
         <source>Service</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="statusPlaceholder" datatype="html">
         <source>Status</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/tests-detail/tests-detail.component.html</context>
@@ -2623,11 +2635,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sla-agreement-detail/sla-agreement-detail.component.html</context>
@@ -2651,7 +2663,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/ns-instance-detail/ns-instance-detail.component.html</context>
@@ -2666,7 +2678,7 @@
         <source>Updated at</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/vnv-network-services-detail/vnv-network-services-detail.component.html</context>
@@ -2682,11 +2694,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -2706,7 +2718,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/ns-instance-detail/ns-instance-detail.component.html</context>
@@ -2717,53 +2729,53 @@
         <source>Confirm the test plan as required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cancellExecutionTestPlan" datatype="html">
         <source>Cancel the execution of the test plan</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="confirmOrCancelExecutionTestPlan" datatype="html">
         <source>Confirm or cancel the execution of the test plan</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="results" datatype="html">
         <source>Results</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">97</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="startedAtPlaceholder" datatype="html">
         <source>Started at</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="endedAtPlaceholder" datatype="html">
         <source>Ended at</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="details" datatype="html">
         <source>Details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/validation-and-verification/test-plan/test-plan.component.html</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="createdBy" datatype="html">
@@ -2839,7 +2851,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/runtime-policy-detail/runtime-policy-detail.component.html</context>
@@ -2897,7 +2909,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-slice-template-detail/sp-slice-template-detail.component.html</context>
@@ -2957,7 +2969,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/sm-network-services-detail/sm-network-services-detail.component.html</context>
@@ -2976,10 +2988,6 @@
           <context context-type="sourcefile">app/validation-and-verification/vnv-packages-detail/vnv-packages-detail.component.html</context>
           <context context-type="linenumber">68</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="id" datatype="html">
         <source>ID</source>
@@ -2989,7 +2997,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/sm-network-services-detail/sm-network-services-detail.component.html</context>
@@ -3054,24 +3062,31 @@
         <source>Type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="eec715de352a6b114713b30b640d319fa78207a0" datatype="html">
         <source>Description</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-platform/sp-network-services-detail/sp-network-services-detail.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <note priority="1" from="description">description</note>
+      </trans-unit>
+      <trans-unit id="functionIDPlaceholder" datatype="html">
+        <source>Function id</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/service-platform/sp-functions-detail/sp-functions-detail.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="selectPolicyPlaceholder" datatype="html">
         <source>Select a policy</source>
@@ -3217,7 +3232,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/ns-instance-detail/ns-instance-detail.component.html</context>
@@ -4379,7 +4394,7 @@
         <source>SLA ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/license-detail/license-detail.component.html</context>
@@ -4390,7 +4405,7 @@
         <source>Error</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/service-management/request-detail/request-detail.component.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="networkServiceInstances" datatype="html">


### PR DESCRIPTION
- Manage OSM elements: parse and display them
- Change tests status filtered in dashboard
- Link packages content with their detailed views 
- Link slices with the detailed views of their components
- Represent OSM network services in test detailed view
- Order test plans decreasingly by updated at
- README update
- General fixes
- Jenkinsfile updated to publish release v5.0

Fixes #414 #357 #418 #416 #419 #420 #417 #421 